### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/okta_admin_activity_from_proxy_query.yml
+++ b/rules/okta_admin_activity_from_proxy_query.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Admin Functions Access Through Proxy
-enabled: true
 description: |-
   Detects access to Okta admin functions through proxy.
 

--- a/rules/okta_admin_role_assigned_to_user_or_group.yml
+++ b/rules/okta_admin_role_assigned_to_user_or_group.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Admin Role Assigned to an User or Group
-enabled: true
 description: |-
   Detects when an the Administrator role is assigned to an user or group.
 

--- a/rules/okta_admin_role_assignment_created.yml
+++ b/rules/okta_admin_role_assignment_created.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Admin Role Assignment Created
-enabled: true
 description: |-
   Detects when a new admin role assignment is created. Which could be a sign of privilege escalation or persistence
 

--- a/rules/okta_administrator_role_assigned_to_user.yml
+++ b/rules/okta_administrator_role_assigned_to_user.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage and response
   1. Contact the Okta administrator to confirm that the user or users should have administrative privileges.
   2. If the change was not authorized, verify there are no other signals from the Okta administrator.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_api_token_created.yml
+++ b/rules/okta_api_token_created.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta API Token Created
-enabled: true
 description: |-
   Detects when a API token is created
 

--- a/rules/okta_api_token_created_or_enabled.yml
+++ b/rules/okta_api_token_created_or_enabled.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and Response
   Contact the user who created the API token to verify its necessity.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_api_token_revoked.yml
+++ b/rules/okta_api_token_revoked.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta API Token Revoked
-enabled: true
 description: |-
   Detects when a API Token is revoked.
 

--- a/rules/okta_application_modified_or_deleted.yml
+++ b/rules/okta_application_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Application Modified or Deleted
-enabled: true
 description: |-
   Detects when an application is modified or deleted.
 

--- a/rules/okta_application_sign_on_policy_modified_or_deleted.yml
+++ b/rules/okta_application_sign_on_policy_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Application Sign-On Policy Modified or Deleted
-enabled: true
 description: |-
   Detects when an application Sign-on Policy is modified or deleted.
 

--- a/rules/okta_blocked_numerous_requests_from_a_malicious_ip.yml
+++ b/rules/okta_blocked_numerous_requests_from_a_malicious_ip.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage & Response
   1. Verify with the user that they were attempting a request to the target application.
   2. If the request cannot be verified, correlate with other log sources to see if the blocked IP in the title has communicated elsewhere on the network.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_fastpass_phishing_detection.yml
+++ b/rules/okta_fastpass_phishing_detection.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta FastPass Phishing Detection
-enabled: true
 description: |-
   Detects when Okta FastPass prevents a known phishing site.
 

--- a/rules/okta_identity_provider_created.yml
+++ b/rules/okta_identity_provider_created.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Identity Provider Created
-enabled: true
 description: |-
   Detects when a new identity provider is created for Okta.
 

--- a/rules/okta_identity_provider_creation_or_modification.yml
+++ b/rules/okta_identity_provider_creation_or_modification.yml
@@ -12,7 +12,6 @@ description: |
   2. If the user was unaware of the change:
       * Check for any unusual activity from this user, including variations in user agents, IP addresses, and network metadata.
       * Initiate the organization's incident response process and investigate potential account takeovers.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_mfa_bypass_attempted.yml
+++ b/rules/okta_mfa_bypass_attempted.yml
@@ -11,7 +11,6 @@ description: |-
 
   ## Triage and Response
   Contact the user who attempted to bypass MFA to verify the legitimacy of the request.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_mfa_reset_or_deactivated.yml
+++ b/rules/okta_mfa_reset_or_deactivated.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta MFA Reset or Deactivated
-enabled: true
 description: |-
   Detects when an attempt at deactivating  or resetting MFA.
 

--- a/rules/okta_network_zone_deactivated_or_deleted.yml
+++ b/rules/okta_network_zone_deactivated_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Network Zone Deactivated or Deleted
-enabled: true
 description: |-
   Detects when an Network Zone is Deactivated or Deleted.
 

--- a/rules/okta_phishing_detection_with_fastpass_origin_check.yml
+++ b/rules/okta_phishing_detection_with_fastpass_origin_check.yml
@@ -12,7 +12,6 @@ description: |-
   2. Determine if any other users have authenticated from this address.
   3. If yes, clear any user sessions and reset passwords if users entered a password during authentication.
   4. Initiate your organization's incident response process and investigate for potential account takeovers.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_policy_modified_or_deleted.yml
+++ b/rules/okta_policy_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Policy Modified or Deleted
-enabled: true
 description: |-
   Detects when an Okta policy is modified or deleted.
 

--- a/rules/okta_policy_rule_deleted.yml
+++ b/rules/okta_policy_rule_deleted.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage and response
   1. Contact the Okta administrator to confirm that the user should be deleting policy rules.
   2. If the change was not authorized, verify there are no other signals from the user.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_policy_rule_modified_or_deleted.yml
+++ b/rules/okta_policy_rule_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Policy Rule Modified or Deleted
-enabled: true
 description: |-
   Detects when an Policy Rule is Modified or Deleted.
 

--- a/rules/okta_security_threat_detected.yml
+++ b/rules/okta_security_threat_detected.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Security Threat Detected
-enabled: true
 description: |-
   Detects when an security threat is detected in Okta.
 

--- a/rules/okta_suspicious_activity_enduser_report.yml
+++ b/rules/okta_suspicious_activity_enduser_report.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Suspicious Activity Reported by End-user
-enabled: true
 description: |-
   Detects when an Okta end-user reports activity by their account as being potentially suspicious.
 

--- a/rules/okta_unauthorized_access_to_app.yml
+++ b/rules/okta_unauthorized_access_to_app.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta Unauthorized Access to App
-enabled: true
 description: |-
   Detects when unauthorized access to app occurs.
 

--- a/rules/okta_user_access_denied_to_sign_on.yml
+++ b/rules/okta_user_access_denied_to_sign_on.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage and Response
   1. Inspect the target array to understand the reason for access denial.
   2. Contact the user to confirm if they attempted to access the app or if their account may be compromised.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_user_account_locked_out.yml
+++ b/rules/okta_user_account_locked_out.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta User Account Locked Out
-enabled: true
 description: |-
   Detects when an user account is locked out.
 

--- a/rules/okta_user_attempted_to_access_unauthorized_app.yml
+++ b/rules/okta_user_attempted_to_access_unauthorized_app.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage and response
   1. Verify if the user should have access to the app.
   2. Contact the user to confirm if they attempted access or if their account may be compromised.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_user_reported_suspicious_activity.yml
+++ b/rules/okta_user_reported_suspicious_activity.yml
@@ -17,7 +17,6 @@ description: |-
   2. Check for any other activity from this address using the IP Investigation dashboard.
   3. If the activity appears harmful:
       * Initiate your organization's incident response process and investigate for any account takeovers.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:okta

--- a/rules/okta_user_session_start_via_anonymised_proxy.yml
+++ b/rules/okta_user_session_start_via_anonymised_proxy.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Okta User Session Start Via An Anonymising Proxy Service
-enabled: true
 description: |-
   Detects when an Okta user session starts where the user is behind an anonymising proxy service.
 


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.